### PR TITLE
ENG-1912 - feat: enable/disable submit btn for atomic banks based on change events

### DIFF
--- a/collect-atomic-banks-with-elements/public/index.html
+++ b/collect-atomic-banks-with-elements/public/index.html
@@ -32,6 +32,7 @@
     <button
       id="submit_button"
       type="button"
+      disabled
       onclick="submitBank()"
     >
       Submit

--- a/collect-atomic-banks-with-elements/public/index.js
+++ b/collect-atomic-banks-with-elements/public/index.js
@@ -5,6 +5,9 @@ const ELEMENTS_KEY = 'key_XVB48UzHJ57TdPtmLhJa9e';
 let routingNumber;
 let accountNumber;
 
+let routingNumberComplete = false;
+let accountNumberNotEmpty = false;
+
 const options = {
   style: {
     fonts: [
@@ -64,6 +67,24 @@ window.addEventListener('load', async () => {
 
   await routingNumber.mount('#routing_number');
   await accountNumber.mount('#account_number');
+
+  const submitBtn = document.querySelector('#submit_button');
+
+  // check if routing number is complete (mask filled)
+  routingNumber.on('change', (event) => {
+    routingNumberComplete = event.complete;
+
+    // update if btn is disabled
+    submitBtn.disabled = !(routingNumberComplete && accountNumberNotEmpty);
+  });
+
+  // check if account number is not empty
+  accountNumber.on('change', (event) => {
+    accountNumberNotEmpty = !event.empty;
+
+    // update if btn is disabled
+    submitBtn.disabled = !(routingNumberComplete && accountNumberNotEmpty);
+  });
 });
 
 function disableBank() {

--- a/cypress/integration/collect-atomic-banks-with-elements/bank.spec.js
+++ b/cypress/integration/collect-atomic-banks-with-elements/bank.spec.js
@@ -8,6 +8,35 @@ context('bank tokenization', () => {
     cy.wait(1500);
   });
 
+  it('should enable/disable submit btn based on change events', () => {
+    cy.get('button').contains('Submit').should('be.disabled');
+
+    cy.get('#routing_number>iframe').iframe(() => {
+      cy.get('input').eq(0).type('021000021');
+    });
+
+    cy.get('button').contains('Submit').should('be.disabled');
+
+    cy.get('#account_number>iframe').iframe(() => {
+      cy.get('input')
+        .eq(0)
+        .type(
+          chance.string({
+            numeric: true,
+            length: 10,
+          })
+        );
+    });
+
+    cy.get('button').contains('Submit').should('be.enabled');
+
+    cy.get('#routing_number>iframe').iframe(() => {
+      cy.get('input').eq(0).type('{backspace}');
+    });
+
+    cy.get('button').contains('Submit').should('be.disabled');
+  });
+
   it(`should tokenize/fund bank`, () => {
     cy.intercept('POST', 'https://api.basistheory.com/atomic/banks').as(
       'tokenize'


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Enable/Disable the atomic banks `submit` button based on routing/account number change events.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
